### PR TITLE
fix: enable vercel domains in cors to get rid of its rejections and s…

### DIFF
--- a/packages/yield-backend/src/lib/express/index.ts
+++ b/packages/yield-backend/src/lib/express/index.ts
@@ -22,9 +22,10 @@ const { handler, middleware } = createVincentUserMiddleware({
   userKey: 'user',
 });
 
+const VERCEL_DOMAINS = /https:\/\/.*-lit-protocol\.vercel\.app$/;
 const corsConfig = {
   optionsSuccessStatus: 204,
-  origin: IS_DEVELOPMENT ? true : CORS_ALLOWED_DOMAINS,
+  origin: IS_DEVELOPMENT ? true : [VERCEL_DOMAINS, ...CORS_ALLOWED_DOMAINS],
 };
 
 export const registerRoutes = (app: Express) => {


### PR DESCRIPTION
# Description

This PR enables vercel temporary domains in CORS so we can test on them and we stop getting the Sentry error of the server rejecting those requests
