### PR TITLE
feat: drop sentry events containing third party frames

### DIFF
--- a/packages/yield-frontend/src/main.tsx
+++ b/packages/yield-frontend/src/main.tsx
@@ -18,6 +18,12 @@ if (VITE_SENTRY_DSN) {
     dsn: VITE_SENTRY_DSN,
     enabled: !VITE_IS_DEVELOPMENT,
     sendDefaultPii: true,
+    integrations: [
+      Sentry.thirdPartyErrorFilterIntegration({
+        behaviour: 'drop-error-if-contains-third-party-frames',
+        filterKeys: ['vincent-yield-frontend'],
+      }),
+    ],
   });
 }
 

--- a/packages/yield-frontend/vite.config.ts
+++ b/packages/yield-frontend/vite.config.ts
@@ -19,9 +19,10 @@ export default defineConfig(({ command }) => {
       ...(sentryEnabled
         ? [
             sentryVitePlugin({
+              applicationKey: 'vincent-yield-frontend',
+              authToken: process.env.SENTRY_AUTH_TOKEN,
               org: 'lit-protocol-lw',
               project: 'vincent-yield-frontend',
-              authToken: process.env.SENTRY_AUTH_TOKEN,
             }),
           ]
         : []),


### PR DESCRIPTION
# Description

This PR adds a Sentry integration to not create events when errors contain third party integrations (someone else's code was involved in the error)