### PR TITLE
fix: jwt accessor mapping to vy model

### DIFF
--- a/packages/yield-backend/src/lib/express/schedules.ts
+++ b/packages/yield-backend/src/lib/express/schedules.ts
@@ -39,8 +39,11 @@ export const handleCreateScheduleRoute = async (
     const { app, pkpInfo } = getAppAndPKPInfoFromJWT(req);
 
     const scheduleParams = ScheduleParamsSchema.parse({
-      app,
       pkpInfo,
+      app: {
+        id: app.appId,
+        version: app.version,
+      },
     });
 
     const schedule = await createJob({ ...scheduleParams }, { interval: 'weekly' });
@@ -81,8 +84,11 @@ export const handleDeleteScheduleRoute = async (
     const { app, pkpInfo } = getAppAndPKPInfoFromJWT(req);
 
     const scheduleParams = ScheduleParamsSchema.parse({
-      app,
       pkpInfo,
+      app: {
+        id: app.appId,
+        version: app.version,
+      },
     });
     const { scheduleId } = ScheduleIdentitySchema.parse(req.params);
 


### PR DESCRIPTION
# Description

When migrating to standard accessors a mapping was missed that made a zod schema fail. This was reported and reproduced by Eli

This mapping missing caused the following error:
```
HTTP error! status: 500
{
"error": "[\n {\n "code": "invalid_type",\n "expected": "number",\n "received": "undefined",\n "path": [\n "app",\n "id"\n ],\n "message": "Required"\n }\n]"
}
```

# Testing

- Verified mapping failure on local
- Created and stopped a schedule after adding the required mapping