### PR TITLE
feat: resync balance when agent starts or stops

### DIFF
--- a/packages/yield-frontend/src/components/dashboard.tsx
+++ b/packages/yield-frontend/src/components/dashboard.tsx
@@ -102,7 +102,9 @@ export const Dashboard: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [createSchedule, getSchedules]);
+
+    refetchBalance();
+  }, [createSchedule, getSchedules, refetchBalance]);
 
   const handleStopSchedule = useCallback(
     async (scheduleId: string) => {
@@ -120,8 +122,10 @@ export const Dashboard: React.FC = () => {
       } finally {
         setStoppingSchedule(null);
       }
+
+      refetchBalance();
     },
-    [deleteSchedule, getSchedules]
+    [deleteSchedule, getSchedules, refetchBalance]
   );
 
   if (!authInfo?.pkp.ethAddress) {


### PR DESCRIPTION
# Description

When the agent started/stopped we were not re-syncing the balance from the chain thus showing an outdated amount. Most of the times 0, freaking users

# Testing

- Locally stopped and started an agent to verify the balance is correctly shown at each step
[Screencast from 08-09-25 10:47:52.webm](https://github.com/user-attachments/assets/d4102db8-9252-45ba-90dc-07497995236f)
 