### PR TITLE
feat: add vercel routing rules

### DIFF
--- a/packages/yield-frontend/vercel.json
+++ b/packages/yield-frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/((?!api/|assets/|_next/|favicon.ico|.*\\.).*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds vercel routing rules to redirect most paths to the main index file. This fixes /dashboard returning 404

