### PR TITLE
chore(dashboard): add dashboard button to header

### DIFF
--- a/packages/yield-frontend/src/components/ui/header.tsx
+++ b/packages/yield-frontend/src/components/ui/header.tsx
@@ -36,6 +36,15 @@ export const Header: React.FC<HeaderProps> = ({ title, isDark, onToggleTheme, ri
           <Button
             variant="secondary-outline"
             size="sm"
+            onClick={() => window.open('https://dashboard.heyvincent.ai/user/apps', '_blank')}
+            className="px-2 sm:px-3"
+            title="Open Vincent Dashboard"
+          >
+            Dashboard
+          </Button>
+          <Button
+            variant="secondary-outline"
+            size="sm"
             onClick={onToggleTheme}
             className="px-2 sm:px-3"
           >


### PR DESCRIPTION
Simple Dashboard button in the header, just takes the user to `/user/apps`

<img width="572" height="340" alt="image" src="https://github.com/user-attachments/assets/2caec9f8-4ff8-4020-892e-261c93cdbf57" />
<img width="580" height="398" alt="image" src="https://github.com/user-attachments/assets/d5a0d0a0-3a33-4746-a8d1-56136f947c96" />
